### PR TITLE
Adds emoji support to Dockerized UCM 🌝

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM debian:bookworm
 
 ARG UCM_VERSION
 
-RUN apt-get update && apt-get install -y apt-transport-https ca-certificates
+RUN apt-get update && apt-get install -y apt-transport-https ca-certificates && apt-get install fonts-noto-color-emoji
 COPY public.gpg /etc/apt/trusted.gpg.d/unison-computing.gpg
 COPY unison-computing.list /etc/apt/sources.list.d/unison-computing.list
 COPY backports.list /etc/apt/sources.list.d/backports.list


### PR DESCRIPTION
Dockerized UCM before adding fonts-noto-color-emoji: 

![Screenshot 2025-01-06 at 11 19 04 AM](https://github.com/user-attachments/assets/a9d2283c-1f6d-4169-ba33-c74a74847724)

Dockerized UCM after adding fonts-noto-color-emoji: 

![Screenshot 2025-01-06 at 11 17 19 AM](https://github.com/user-attachments/assets/22c5e2e5-5ac4-4dfc-81f0-e8ad8610854d)

@stew, I am on a Mac (m1) which introduces some weirdness when building the docker image; so I would double-check that this solves the emoji issue on your Linux machine before merging. 